### PR TITLE
feat: Add WebSocket client webpage

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -1,16 +1,18 @@
 # WebSocket Client Webpage
 
-This directory contains a simple HTML, CSS, and JavaScript based WebSocket client.
-It allows you to connect to a WebSocket server, send JSON messages, and view received messages.
+This directory contains a modern HTML, CSS, and JavaScript based WebSocket client.
+It allows you to connect to a WebSocket server, send JSON messages, and view received messages with an enhanced user interface and improved JSON handling capabilities.
 
 ## Features
 
 -   Connect to a specified WebSocket server URL.
 -   Disconnect from the server.
--   Display connection status (Idle, Connecting, Connected, Disconnected, Error).
--   Text area to compose JSON messages.
--   Button to send the composed message.
--   Text area to display messages received from the server (attempts to pretty-print JSON).
+-   Display connection status (Idle, Connecting, Connected, Disconnected, Error) with color-coded visual indicators.
+-   Text area to compose JSON messages with real-time validation.
+-   Real-time JSON validation with error feedback.
+-   One-click JSON formatting button to properly indent and format JSON.
+-   Smart button state management (send button only enabled when connected and JSON is valid).
+-   Text area to display messages received from the server (automatically pretty-prints JSON).
 -   Button to clear the received messages log.
 
 ## How to Use
@@ -26,11 +28,19 @@ It allows you to connect to a WebSocket server, send JSON messages, and view rec
 3.  **Connect to the WebSocket Server:**
     *   Verify or enter the WebSocket server URL in the input field.
     *   Click the "Connect" button.
-    *   The status should update to "Connected" if successful.
+    *   The status should update to "Connected" with a green indicator if successful.
 
-4.  **Send and Receive Messages:**
+4.  **Compose and Validate JSON Messages:**
     *   Once connected, type your JSON message into the "Send Message (JSON)" text area.
-    *   Click the "Send" button.
+    *   The system will automatically validate your JSON in real-time as you type.
+    *   A validation status indicator will appear in the top-right corner of the text area:
+        * Green indicator with "格式正确" means the JSON is valid.
+        * Red indicator with an error message means the JSON is invalid.
+    *   If your JSON is not properly formatted, click the "格式化" button to automatically format it with proper indentation.
+
+5.  **Send and Receive Messages:**
+    *   The "Send" button will only be enabled when both connected to the server and the JSON is valid.
+    *   Click the "Send" button to transmit your message.
     *   Messages sent and received will appear in the "Received Messages" text area.
 
 5.  **Disconnect:**
@@ -38,6 +48,6 @@ It allows you to connect to a WebSocket server, send JSON messages, and view rec
 
 ## Files
 
--   `index.html`: The main HTML structure of the webpage.
--   `style.css`: CSS styles for the webpage.
--   `app.js`: JavaScript logic for WebSocket communication and UI interactions.
+-   `index.html`: The main HTML structure of the webpage with a modern, responsive layout.
+-   `style.css`: CSS styles for the webpage, including modern design elements, color-coded status indicators, and responsive design.
+-   `app.js`: JavaScript logic for WebSocket communication, UI interactions, real-time JSON validation, and formatting functionality.

--- a/public/README.md
+++ b/public/README.md
@@ -1,0 +1,43 @@
+# WebSocket Client Webpage
+
+This directory contains a simple HTML, CSS, and JavaScript based WebSocket client.
+It allows you to connect to a WebSocket server, send JSON messages, and view received messages.
+
+## Features
+
+-   Connect to a specified WebSocket server URL.
+-   Disconnect from the server.
+-   Display connection status (Idle, Connecting, Connected, Disconnected, Error).
+-   Text area to compose JSON messages.
+-   Button to send the composed message.
+-   Text area to display messages received from the server (attempts to pretty-print JSON).
+-   Button to clear the received messages log.
+
+## How to Use
+
+1.  **Ensure a WebSocket server is running.**
+    *   The client defaults to connecting to `ws://localhost:5151`. You can change this URL in the input field on the page.
+    *   The backend service this page is intended to communicate with (as suggested by the project's `src/index.ts`) is expected to be at this address.
+
+2.  **Open `index.html` in your web browser.**
+    *   Navigate to the `public` directory of this project.
+    *   Open the `index.html` file directly in a modern web browser (e.g., Chrome, Firefox, Edge, Safari). No special build step is required for this simple client.
+
+3.  **Connect to the WebSocket Server:**
+    *   Verify or enter the WebSocket server URL in the input field.
+    *   Click the "Connect" button.
+    *   The status should update to "Connected" if successful.
+
+4.  **Send and Receive Messages:**
+    *   Once connected, type your JSON message into the "Send Message (JSON)" text area.
+    *   Click the "Send" button.
+    *   Messages sent and received will appear in the "Received Messages" text area.
+
+5.  **Disconnect:**
+    *   Click the "Disconnect" button to close the WebSocket connection.
+
+## Files
+
+-   `index.html`: The main HTML structure of the webpage.
+-   `style.css`: CSS styles for the webpage.
+-   `app.js`: JavaScript logic for WebSocket communication and UI interactions.

--- a/public/app.js
+++ b/public/app.js
@@ -58,12 +58,33 @@ document.addEventListener('DOMContentLoaded', () => {
 
         websocket.onmessage = (event) => {
             let messageData = event.data;
+            
+            // 处理Blob类型数据
+            if (messageData instanceof Blob) {
+                const reader = new FileReader();
+                reader.onload = () => {
+                    try {
+                        // 尝试解析为JSON并美化输出
+                        const jsonStr = reader.result;
+                        const parsedJson = JSON.parse(jsonStr);
+                        messageData = JSON.stringify(parsedJson, null, 2); // 美化输出
+                    } catch (e) {
+                        // 如果不是JSON，按原样显示
+                        messageData = reader.result;
+                    }
+                    logReceivedMessage(messageData);
+                };
+                reader.readAsText(messageData);
+                return;
+            }
+            
+            // 处理文本数据
             try {
-                // Try to parse as JSON and pretty-print
+                // 尝试解析为JSON并美化输出
                 const parsedJson = JSON.parse(messageData);
-                messageData = JSON.stringify(parsedJson, null, 2); // Pretty print
+                messageData = JSON.stringify(parsedJson, null, 2); // 美化输出
             } catch (e) {
-                // If not JSON, display as is
+                // 如果不是JSON，按原样显示
             }
             logReceivedMessage(messageData);
         };

--- a/public/app.js
+++ b/public/app.js
@@ -5,6 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const statusDisplay = document.getElementById('status');
     const messageToSendInput = document.getElementById('messageToSend');
     const sendBtn = document.getElementById('sendBtn');
+    const formatJsonBtn = document.getElementById('formatJsonBtn');
+    const jsonValidationStatus = document.getElementById('jsonValidationStatus');
     const receivedMessagesTextarea = document.getElementById('receivedMessages');
     const clearLogBtn = document.getElementById('clearLogBtn');
 
@@ -48,8 +50,10 @@ document.addEventListener('DOMContentLoaded', () => {
             updateStatus(`Connected to ${url}`);
             connectBtn.disabled = true;
             disconnectBtn.disabled = false;
-            sendBtn.disabled = false;
             wsUrlInput.disabled = true;
+            
+            // 连接成功后，验证当前JSON输入是否有效
+            validateJsonInput();
         };
 
         websocket.onmessage = (event) => {
@@ -102,6 +106,12 @@ document.addEventListener('DOMContentLoaded', () => {
         disconnectBtn.disabled = true;
         sendBtn.disabled = true;
         wsUrlInput.disabled = false;
+        
+        // 清除JSON验证状态
+        if (jsonValidationStatus) {
+            jsonValidationStatus.textContent = '';
+            jsonValidationStatus.classList.remove('json-valid', 'json-invalid');
+        }
     }
 
     function sendMessage() {
@@ -116,23 +126,77 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
+        // 由于我们已经在输入时验证了JSON，并且只有在JSON有效时才启用发送按钮
+        // 所以这里可以直接发送，不需要再次验证
+        websocket.send(message);
+        const timestamp = new Date().toLocaleTimeString();
+        receivedMessagesTextarea.value += `[${timestamp}] Sent: ${message}\n\n`;
+        receivedMessagesTextarea.scrollTop = receivedMessagesTextarea.scrollHeight;
+        // messageToSendInput.value = ''; // Clear after sending if desired
+    }
+
+    // 验证JSON格式是否合法
+    function validateJson(jsonString) {
+        if (!jsonString.trim()) {
+            return { valid: false, message: '输入为空' };
+        }
+        
         try {
-            // Validate JSON before sending (optional, but good practice)
-            JSON.parse(message);
-            websocket.send(message);
-            const timestamp = new Date().toLocaleTimeString();
-            receivedMessagesTextarea.value += `[${timestamp}] Sent: ${message}\n\n`;
-            receivedMessagesTextarea.scrollTop = receivedMessagesTextarea.scrollHeight;
-            // messageToSendInput.value = ''; // Clear after sending if desired
+            JSON.parse(jsonString);
+            return { valid: true, message: '格式正确' };
         } catch (e) {
-            updateStatus(`Invalid JSON: ${e.message}`, true);
-            console.error('Invalid JSON:', e);
+            return { valid: false, message: e.message };
+        }
+    }
+    
+    // 格式化JSON
+    function formatJson() {
+        const jsonString = messageToSendInput.value.trim();
+        if (!jsonString) {
+            updateStatus('无内容可格式化', true);
+            return;
+        }
+        
+        try {
+            const parsedJson = JSON.parse(jsonString);
+            messageToSendInput.value = JSON.stringify(parsedJson, null, 4);
+            updateJsonValidationStatus(true, '格式化成功');
+        } catch (e) {
+            updateStatus(`无法格式化: ${e.message}`, true);
+        }
+    }
+    
+    // 更新JSON验证状态显示
+    function updateJsonValidationStatus(isValid, message) {
+        jsonValidationStatus.textContent = message;
+        jsonValidationStatus.classList.remove('json-valid', 'json-invalid');
+        
+        if (isValid) {
+            jsonValidationStatus.classList.add('json-valid');
+        } else {
+            jsonValidationStatus.classList.add('json-invalid');
+        }
+    }
+    
+    // 实时验证JSON
+    function validateJsonInput() {
+        const result = validateJson(messageToSendInput.value);
+        updateJsonValidationStatus(result.valid, result.message);
+        
+        // 只有在连接状态下且JSON有效时才启用发送按钮
+        if (websocket && websocket.readyState === WebSocket.OPEN) {
+            sendBtn.disabled = !result.valid;
         }
     }
 
+    // 事件监听器
     connectBtn.addEventListener('click', connectWebSocket);
     disconnectBtn.addEventListener('click', () => disconnectWebSocket(true));
     sendBtn.addEventListener('click', sendMessage);
+    formatJsonBtn.addEventListener('click', formatJson);
+    
+    // 输入时实时验证JSON
+    messageToSendInput.addEventListener('input', validateJsonInput);
 
     clearLogBtn.addEventListener('click', () => {
         receivedMessagesTextarea.value = '';
@@ -141,4 +205,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Initial state
     updateStatus('Idle. Enter WebSocket URL and connect.');
+    validateJsonInput(); // 初始验证
 });

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,132 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const wsUrlInput = document.getElementById('wsUrl');
+    const connectBtn = document.getElementById('connectBtn');
+    const disconnectBtn = document.getElementById('disconnectBtn');
+    const statusDisplay = document.getElementById('status');
+    const messageToSendInput = document.getElementById('messageToSend');
+    const sendBtn = document.getElementById('sendBtn');
+    const receivedMessagesTextarea = document.getElementById('receivedMessages');
+    const clearLogBtn = document.getElementById('clearLogBtn');
+
+    let websocket = null;
+
+    function updateStatus(message, isError = false) {
+        statusDisplay.textContent = message;
+        statusDisplay.style.color = isError ? 'red' : 'black';
+        console.log(`Status: ${message}`);
+    }
+
+    function logReceivedMessage(message) {
+        const timestamp = new Date().toLocaleTimeString();
+        receivedMessagesTextarea.value += `[${timestamp}] Received: ${message}\n\n`;
+        receivedMessagesTextarea.scrollTop = receivedMessagesTextarea.scrollHeight; // Auto-scroll
+    }
+
+    function connectWebSocket() {
+        const url = wsUrlInput.value.trim();
+        if (!url) {
+            updateStatus('WebSocket URL cannot be empty.', true);
+            return;
+        }
+
+        updateStatus(`Connecting to ${url}...`);
+        websocket = new WebSocket(url);
+
+        websocket.onopen = () => {
+            updateStatus(`Connected to ${url}`);
+            connectBtn.disabled = true;
+            disconnectBtn.disabled = false;
+            sendBtn.disabled = false;
+            wsUrlInput.disabled = true;
+        };
+
+        websocket.onmessage = (event) => {
+            let messageData = event.data;
+            try {
+                // Try to parse as JSON and pretty-print
+                const parsedJson = JSON.parse(messageData);
+                messageData = JSON.stringify(parsedJson, null, 2); // Pretty print
+            } catch (e) {
+                // If not JSON, display as is
+            }
+            logReceivedMessage(messageData);
+        };
+
+        websocket.onerror = (error) => {
+            updateStatus(`WebSocket Error: ${error.message || 'Unknown error. Check console.'}`, true);
+            console.error('WebSocket Error:', error);
+            // Ensure UI is reset if connection failed
+            if (websocket.readyState !== WebSocket.OPEN) {
+                disconnectWebSocket(false); // Pass false to avoid trying to close a non-existent connection
+            }
+        };
+
+        websocket.onclose = (event) => {
+            updateStatus(`Disconnected. Code: ${event.code}, Reason: ${event.reason || 'No reason given'}`);
+            connectBtn.disabled = false;
+            disconnectBtn.disabled = true;
+            sendBtn.disabled = true;
+            wsUrlInput.disabled = false;
+            websocket = null;
+        };
+    }
+
+    function disconnectWebSocket(notifyServer = true) {
+        if (websocket) {
+            if (notifyServer && websocket.readyState === WebSocket.OPEN) {
+                 // Send a close signal if desired, though WebSocket.close() handles this.
+                 // For some servers, an explicit disconnect message might be useful.
+                 // Example: websocket.send(JSON.stringify({ type: 'disconnect_notice' }));
+                websocket.close(1000, "Client initiated disconnect");
+            } else if (!notifyServer && websocket.readyState !== WebSocket.CLOSED && websocket.readyState !== WebSocket.CLOSING) {
+                // Force close if not notifying server (e.g., connection failed to open)
+                websocket.close();
+            }
+            updateStatus('Disconnected');
+        } else {
+            updateStatus('Already disconnected or never connected.');
+        }
+        connectBtn.disabled = false;
+        disconnectBtn.disabled = true;
+        sendBtn.disabled = true;
+        wsUrlInput.disabled = false;
+    }
+
+    function sendMessage() {
+        if (!websocket || websocket.readyState !== WebSocket.OPEN) {
+            updateStatus('Not connected to WebSocket server.', true);
+            return;
+        }
+
+        const message = messageToSendInput.value.trim();
+        if (!message) {
+            updateStatus('Cannot send an empty message.', true);
+            return;
+        }
+
+        try {
+            // Validate JSON before sending (optional, but good practice)
+            JSON.parse(message);
+            websocket.send(message);
+            const timestamp = new Date().toLocaleTimeString();
+            receivedMessagesTextarea.value += `[${timestamp}] Sent: ${message}\n\n`;
+            receivedMessagesTextarea.scrollTop = receivedMessagesTextarea.scrollHeight;
+            // messageToSendInput.value = ''; // Clear after sending if desired
+        } catch (e) {
+            updateStatus(`Invalid JSON: ${e.message}`, true);
+            console.error('Invalid JSON:', e);
+        }
+    }
+
+    connectBtn.addEventListener('click', connectWebSocket);
+    disconnectBtn.addEventListener('click', () => disconnectWebSocket(true));
+    sendBtn.addEventListener('click', sendMessage);
+
+    clearLogBtn.addEventListener('click', () => {
+        receivedMessagesTextarea.value = '';
+        updateStatus('Message log cleared.');
+    });
+
+    // Initial state
+    updateStatus('Idle. Enter WebSocket URL and connect.');
+});

--- a/public/app.js
+++ b/public/app.js
@@ -12,7 +12,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function updateStatus(message, isError = false) {
         statusDisplay.textContent = message;
-        statusDisplay.style.color = isError ? 'red' : 'black';
+        
+        // 移除所有状态类
+        statusDisplay.classList.remove('status-connected', 'status-error', 'status-connecting');
+        
+        // 根据消息内容添加适当的状态类
+        if (isError) {
+            statusDisplay.classList.add('status-error');
+        } else if (message.includes('Connected to')) {
+            statusDisplay.classList.add('status-connected');
+        } else if (message.includes('Connecting')) {
+            statusDisplay.classList.add('status-connecting');
+        }
+        
         console.log(`Status: ${message}`);
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WebSocket Client</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>WebSocket Client</h1>
+
+    <div class="connection-section">
+        <h2>Connection</h2>
+        <label for="wsUrl">WebSocket URL:</label>
+        <input type="text" id="wsUrl" value="ws://localhost:5151">
+        <button id="connectBtn">Connect</button>
+        <button id="disconnectBtn" disabled>Disconnect</button>
+        <p>Status: <span id="status">Idle</span></p>
+    </div>
+
+    <div class="message-section">
+        <div class="send-message">
+            <h2>Send Message (JSON)</h2>
+            <textarea id="messageToSend" rows="5" placeholder="Enter JSON message here..."></textarea>
+            <button id="sendBtn" disabled>Send</button>
+        </div>
+
+        <div class="received-messages">
+            <h2>Received Messages</h2>
+            <textarea id="receivedMessages" rows="15" readonly placeholder="Messages from server will appear here..."></textarea>
+            <button id="clearLogBtn">Clear Log</button>
+        </div>
+    </div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -5,30 +5,37 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>WebSocket Client</title>
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-    <h1>WebSocket Client</h1>
+    <div class="container">
+        <h1><i class="fas fa-plug"></i> WebSocket Client</h1>
 
-    <div class="connection-section">
-        <h2>Connection</h2>
-        <label for="wsUrl">WebSocket URL:</label>
-        <input type="text" id="wsUrl" value="ws://localhost:5151">
-        <button id="connectBtn">Connect</button>
-        <button id="disconnectBtn" disabled>Disconnect</button>
-        <p>Status: <span id="status">Idle</span></p>
-    </div>
-
-    <div class="message-section">
-        <div class="send-message">
-            <h2>Send Message (JSON)</h2>
-            <textarea id="messageToSend" rows="5" placeholder="Enter JSON message here..."></textarea>
-            <button id="sendBtn" disabled>Send</button>
+        <div class="connection-section">
+            <h2><i class="fas fa-network-wired"></i> Connection</h2>
+            <div class="input-group">
+                <label for="wsUrl">WebSocket URL:</label>
+                <input type="text" id="wsUrl" value="ws://localhost:5151">
+            </div>
+            <div class="button-group">
+                <button id="connectBtn"><i class="fas fa-link"></i> Connect</button>
+                <button id="disconnectBtn" disabled><i class="fas fa-unlink"></i> Disconnect</button>
+            </div>
+            <p class="status-display">Status: <span id="status">Idle</span></p>
         </div>
 
-        <div class="received-messages">
-            <h2>Received Messages</h2>
-            <textarea id="receivedMessages" rows="15" readonly placeholder="Messages from server will appear here..."></textarea>
-            <button id="clearLogBtn">Clear Log</button>
+        <div class="message-section">
+            <div class="send-message">
+                <h2><i class="fas fa-paper-plane"></i> Send Message (JSON)</h2>
+                <textarea id="messageToSend" rows="5" placeholder="Enter JSON message here..."></textarea>
+                <button id="sendBtn" disabled><i class="fas fa-share"></i> Send</button>
+            </div>
+
+            <div class="received-messages">
+                <h2><i class="fas fa-inbox"></i> Received Messages</h2>
+                <textarea id="receivedMessages" rows="15" readonly placeholder="Messages from server will appear here..."></textarea>
+                <button id="clearLogBtn"><i class="fas fa-trash"></i> Clear Log</button>
+            </div>
         </div>
     </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -27,8 +27,14 @@
         <div class="message-section">
             <div class="send-message">
                 <h2><i class="fas fa-paper-plane"></i> Send Message (JSON)</h2>
-                <textarea id="messageToSend" rows="5" placeholder="Enter JSON message here..."></textarea>
-                <button id="sendBtn" disabled><i class="fas fa-share"></i> Send</button>
+                <div class="textarea-container">
+                    <textarea id="messageToSend" rows="5" placeholder="Enter JSON message here..."></textarea>
+                    <div id="jsonValidationStatus" class="json-validation-status"></div>
+                </div>
+                <div class="button-group">
+                    <button id="formatJsonBtn"><i class="fas fa-indent"></i> 格式化</button>
+                    <button id="sendBtn" disabled><i class="fas fa-share"></i> Send</button>
+                </div>
             </div>
 
             <div class="received-messages">

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <div class="container">
-        <h1><i class="fas fa-plug"></i> WebSocket Client</h1>
+        <h1><i class="fas fa-plug"></i> WebSocket DebugTool</h1>
 
         <div class="connection-section">
             <h2><i class="fas fa-network-wired"></i> Connection</h2>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,95 @@
+body {
+    font-family: sans-serif;
+    margin: 20px;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+h1, h2 {
+    color: #333;
+}
+
+.connection-section, .message-section {
+    background-color: #fff;
+    padding: 15px;
+    margin-bottom: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+label {
+    display: inline-block;
+    margin-bottom: 5px;
+}
+
+input[type="text"] {
+    width: calc(100% - 22px); /* Adjust for padding and border */
+    padding: 10px;
+    margin-bottom: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+button {
+    padding: 10px 15px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-right: 5px;
+    margin-bottom: 5px; /* Added for better spacing on smaller screens */
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+button:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+}
+
+#disconnectBtn {
+    background-color: #dc3545;
+}
+
+#disconnectBtn:hover {
+    background-color: #c82333;
+}
+
+textarea {
+    width: calc(100% - 22px); /* Adjust for padding and border */
+    padding: 10px;
+    margin-bottom: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-sizing: border-box;
+    font-family: monospace; /* Good for JSON */
+}
+
+#status {
+    font-weight: bold;
+}
+
+.message-section {
+    display: flex;
+    gap: 20px; /* Space between send and received sections */
+}
+
+.send-message, .received-messages {
+    flex: 1; /* Each takes half the space */
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .message-section {
+        flex-direction: column;
+    }
+
+    input[type="text"], textarea, button {
+        width: 100%; /* Full width on smaller screens */
+        margin-right: 0;
+    }
+}

--- a/public/style.css
+++ b/public/style.css
@@ -150,9 +150,9 @@ button:disabled {
 }
 
 textarea {
-    width: calc(100% - 22px);
+    width: 100%;
     padding: 12px;
-    margin-bottom: 15px;
+    margin-bottom: 0;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
     box-sizing: border-box;
@@ -167,6 +167,33 @@ textarea:focus {
     border-color: var(--primary-color);
     outline: none;
     box-shadow: 0 0 0 3px rgba(74, 111, 165, 0.2);
+}
+
+.textarea-container {
+    position: relative;
+    margin-bottom: 15px;
+    width: calc(100% - 22px);
+}
+
+.json-validation-status {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    padding: 3px 8px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    opacity: 0.9;
+}
+
+.json-valid {
+    background-color: rgba(42, 157, 143, 0.2);
+    color: var(--success-color);
+}
+
+.json-invalid {
+    background-color: rgba(230, 57, 70, 0.2);
+    color: var(--secondary-color);
 }
 
 #status {

--- a/public/style.css
+++ b/public/style.css
@@ -1,85 +1,211 @@
-body {
-    font-family: sans-serif;
-    margin: 20px;
-    background-color: #f4f4f4;
-    color: #333;
+/* Modern WebSocket Client Styles */
+:root {
+    --primary-color: #4a6fa5;
+    --primary-hover: #3a5a8c;
+    --secondary-color: #e63946;
+    --secondary-hover: #c1121f;
+    --background-color: #f8f9fa;
+    --card-bg: #ffffff;
+    --text-color: #2b2d42;
+    --border-color: #dee2e6;
+    --success-color: #2a9d8f;
+    --info-color: #457b9d;
+    --border-radius: 8px;
+    --box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    --transition: all 0.3s ease;
 }
 
-h1, h2 {
-    color: #333;
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    margin: 0;
+    padding: 20px;
+    background-color: var(--background-color);
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.input-group {
+    margin-bottom: 15px;
+}
+
+.button-group {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 15px;
+    flex-wrap: wrap;
+}
+
+.status-display {
+    margin-top: 15px;
+    font-size: 1.1rem;
+}
+
+i {
+    margin-right: 5px;
+}
+
+h1 {
+    text-align: center;
+    color: var(--primary-color);
+    margin-bottom: 30px;
+    font-size: 2.5rem;
+    font-weight: 600;
+}
+
+h2 {
+    color: var(--primary-color);
+    font-size: 1.5rem;
+    margin-bottom: 15px;
+    font-weight: 500;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 8px;
 }
 
 .connection-section, .message-section {
-    background-color: #fff;
-    padding: 15px;
-    margin-bottom: 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    background-color: var(--card-bg);
+    padding: 25px;
+    margin-bottom: 30px;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    transition: var(--transition);
+}
+
+.connection-section:hover, .message-section:hover {
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
 }
 
 label {
     display: inline-block;
-    margin-bottom: 5px;
+    margin-bottom: 8px;
+    font-weight: 500;
+    color: var(--text-color);
 }
 
 input[type="text"] {
-    width: calc(100% - 22px); /* Adjust for padding and border */
-    padding: 10px;
-    margin-bottom: 10px;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+    width: calc(100% - 22px);
+    padding: 12px;
+    margin-bottom: 15px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
     box-sizing: border-box;
+    transition: var(--transition);
+    font-size: 1rem;
+}
+
+input[type="text"]:focus {
+    border-color: var(--primary-color);
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(74, 111, 165, 0.2);
 }
 
 button {
-    padding: 10px 15px;
-    background-color: #007bff;
+    padding: 12px 20px;
+    background-color: var(--primary-color);
     color: white;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--border-radius);
     cursor: pointer;
-    margin-right: 5px;
-    margin-bottom: 5px; /* Added for better spacing on smaller screens */
+    margin-right: 10px;
+    margin-bottom: 10px;
+    font-weight: 500;
+    transition: var(--transition);
+    font-size: 1rem;
 }
 
 button:hover {
-    background-color: #0056b3;
+    background-color: var(--primary-hover);
+    transform: translateY(-2px);
+}
+
+button:active {
+    transform: translateY(0);
 }
 
 button:disabled {
     background-color: #ccc;
     cursor: not-allowed;
+    transform: none;
 }
 
 #disconnectBtn {
-    background-color: #dc3545;
+    background-color: var(--secondary-color);
 }
 
 #disconnectBtn:hover {
-    background-color: #c82333;
+    background-color: var(--secondary-hover);
+}
+
+#clearLogBtn {
+    background-color: var(--info-color);
+}
+
+#clearLogBtn:hover {
+    background-color: #3d6990;
 }
 
 textarea {
-    width: calc(100% - 22px); /* Adjust for padding and border */
-    padding: 10px;
-    margin-bottom: 10px;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+    width: calc(100% - 22px);
+    padding: 12px;
+    margin-bottom: 15px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
     box-sizing: border-box;
-    font-family: monospace; /* Good for JSON */
+    font-family: 'Consolas', 'Courier New', monospace;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    resize: vertical;
+    transition: var(--transition);
+}
+
+textarea:focus {
+    border-color: var(--primary-color);
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(74, 111, 165, 0.2);
 }
 
 #status {
     font-weight: bold;
+    padding: 5px 10px;
+    border-radius: 20px;
+    display: inline-block;
+    background-color: #f8f9fa;
+    border: 1px solid var(--border-color);
 }
 
 .message-section {
     display: flex;
-    gap: 20px; /* Space between send and received sections */
+    gap: 30px;
 }
 
 .send-message, .received-messages {
-    flex: 1; /* Each takes half the space */
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Status colors */
+.status-connected {
+    color: var(--success-color);
+    background-color: rgba(42, 157, 143, 0.1);
+    border-color: var(--success-color);
+}
+
+.status-error {
+    color: var(--secondary-color);
+    background-color: rgba(230, 57, 70, 0.1);
+    border-color: var(--secondary-color);
+}
+
+.status-connecting {
+    color: var(--info-color);
+    background-color: rgba(69, 123, 157, 0.1);
+    border-color: var(--info-color);
 }
 
 /* Responsive adjustments */
@@ -89,7 +215,19 @@ textarea {
     }
 
     input[type="text"], textarea, button {
-        width: 100%; /* Full width on smaller screens */
+        width: 100%;
         margin-right: 0;
+    }
+    
+    body {
+        padding: 10px;
+    }
+    
+    .connection-section, .message-section {
+        padding: 15px;
+    }
+    
+    h1 {
+        font-size: 2rem;
     }
 }


### PR DESCRIPTION
This commit introduces a new standalone WebSocket client webpage. The client is built with HTML, CSS, and vanilla JavaScript and is located in the `public/` directory.

Key features:
- Connect to and disconnect from a WebSocket server.
- Input for WebSocket server URL (defaults to ws://localhost:5151).
- Display connection status.
- Textarea for composing JSON messages to send.
- Textarea for displaying received messages (attempts to pretty-print JSON).
- Buttons for sending messages and clearing the received message log.
- Basic responsive styling.

A `public/README.md` is included with instructions on how to run and use the webpage. This webpage allows you to directly interact with a WebSocket server, send arbitrary JSON messages, and view responses, fulfilling the requirements of the initial issue.